### PR TITLE
root path to user edit

### DIFF
--- a/app/components/app_tab_panel/javascripts/sign_out.js
+++ b/app/components/app_tab_panel/javascripts/sign_out.js
@@ -19,6 +19,6 @@
     });
   },
   onChangeAccountInfo: function(){
-    window.location.href="users/edit";
+    window.location.href="/users/edit";
   }
 }


### PR DESCRIPTION
Fixed issue where clicking Change Password in Admin view did not work because the redirect path was not respective to the root url.
