### PR TITLE
Issue #109: db:seed failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See [guides](doc/guides.md)
 1. Install Docker Toolbox <https://www.docker.com/toolbox>
 1. Make sure you have a machine running: `docker-machine start default && eval "$(docker-machine env default)"`
 1. Execute `docker-compose build`
-1. Execute `docker-compose run web rake db:create db:migrate db:seed`
+1. Execute `docker-compose run web rake db:setup`
 1. Execute `docker-compose up`
 1. If using Docker Toolbox, use `docker-machine ip default` to get the IP where the server is running.
 1. Test the Rails server is running with by visiting `<INSERT IP>:8080` in your browser.

--- a/db/migrate/20131019150459_create_bike_wheel_sizes.rb
+++ b/db/migrate/20131019150459_create_bike_wheel_sizes.rb
@@ -10,10 +10,6 @@ class CreateBikeWheelSizes < ActiveRecord::Migration
       t.string :description
       t.string :tire_common_score
     end
-
-    #create the default undetermined wheel size record
-    BikeWheelSize.create( twmm: 0, rdmm: 0, rdin: 0, twin: 0, rdfr: 0, twfr: 0, description: "UNDETERMINED", tire_common_score: 0)
-    ActiveRecord::Base.connection.execute(IO.read(File.join(Rails.root, "db", "seed", "sql", "common_wheel_sizes.sql")))
   end
 
   def down

--- a/db/seed/sql/common_wheel_sizes.sql
+++ b/db/seed/sql/common_wheel_sizes.sql
@@ -1,3 +1,6 @@
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+INSERT INTO bike_wheel_sizes (TWMM, RDMM,RDIN,TWIN,RDFR,TWFR,DESCRIPTION,tire_common_score) values (0,0,0,0,0,0,'UNDETERMINED',0);
 INSERT INTO bike_wheel_sizes (TWMM, RDMM,RDIN,TWIN,RDFR,TWFR,DESCRIPTION,tire_common_score) values (54,110,'8 1/2','2','','','',1);
 INSERT INTO bike_wheel_sizes (TWMM, RDMM,RDIN,TWIN,RDFR,TWFR,DESCRIPTION,tire_common_score) values (62,203,'12','1/2 x 2 1/4','320 ','57','',1);
 INSERT INTO bike_wheel_sizes (TWMM, RDMM,RDIN,TWIN,RDFR,TWFR,DESCRIPTION,tire_common_score) values (47,305,'16','1,75 [x 2]','','','',1);
@@ -35,3 +38,4 @@ INSERT INTO bike_wheel_sizes (TWMM, RDMM,RDIN,TWIN,RDFR,TWFR,DESCRIPTION,tire_co
 INSERT INTO bike_wheel_sizes (TWMM, RDMM,RDIN,TWIN,RDFR,TWFR,DESCRIPTION,tire_common_score) values (28,630,'27','1 1/8 [1 1/4 fifty]','','','',1);
 INSERT INTO bike_wheel_sizes (TWMM, RDMM,RDIN,TWIN,RDFR,TWFR,DESCRIPTION,tire_common_score) values (32,630,'27','1 1/4','','','',1);
 INSERT INTO bike_wheel_sizes (TWMM, RDMM,RDIN,TWIN,RDFR,TWFR,DESCRIPTION,tire_common_score) values (40,635,'28','1 1/2 [1 3/8]','700 ','38B [35B]','',1);
+COMMIT;

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,10 +18,12 @@ if BikeBrand.all.empty? and BikeModel.all.empty?
   # so that the PG table ID sequence is incremented
   #
   # Note the drop(1) which assumes we have a junk PRAGMA line at the top
-  load_statements = File.readlines(File.join(Rails.root, 'db', 'seed', 'sql', 'bike_brands_and_models.sql')).drop(1).map do |statement|
-    statement.sub(/VALUES\(\d+,/, 'VALUES(DEFAULT,')
+  ['common_wheel_sizes.sql', 'bike_brands_and_models.sql'].each do |sql|
+    load_statements = File.readlines(File.join(Rails.root, 'db', 'seed', 'sql', sql)).drop(1).map do |statement|
+      statement.sub(/VALUES\(\d+,/, 'VALUES(DEFAULT,')
+    end
+    ActiveRecord::Base.connection.execute(load_statements.join)
   end
-  ActiveRecord::Base.connection.execute(load_statements.join)
 end
 
 if Rails.env.development?

--- a/doc/local_dev_setup.md
+++ b/doc/local_dev_setup.md
@@ -7,8 +7,7 @@
 1. Install Postgres (Mac OSX instructions below)
 1. Copy over DB config:  `cp config/database.yml.example config/database.yml`
 1. Update config with your database (velocipede), user (velocipede), and password.
-1. `rake db:create db:migrate`
-1. `rake db:seed`
+1. `rake db:setup`
 1. Download extJS 4.1 (A version of 4.1 is hosted here: http://my.jasondenney.com/extjs-4.1.1.zip) Latest versions at http://www.sencha.com/products/extjs. Unzip and place where ever you like.
 1. Link to your extJS folder path under `public/extjs`: (From app root) `ln -s /MY/PATH/extjs/ public/extjs`
 1. `rails s`


### PR DESCRIPTION
The problem was due to some data filling in during migrations applying. Database population should be a burden of db:seed.

Also, it's more correct to setup a new dev instance via db:setup as it doesn't run all the migrations but initialize the database with the schema.