### PR TITLE
Enhance Dockerfile / Fix missing extjs file bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,15 @@ RUN apt-get update && apt-get install -y nodejs --no-install-recommends && \
 COPY Gemfile /usr/src/app/
 COPY Gemfile.lock /usr/src/app/
 
-RUN bundle install
+RUN env NOKOGIRI_USE_SYSTEM_LIBRARIES=true bundle install
 
-COPY install_extjs.rb /usr/src/app/
-RUN /usr/src/app/install_extjs.rb
+#COPY install_extjs.rb /usr/src/app/
+#RUN /usr/src/app/install_extjs.rb
+
+COPY  extjs-4.1.1.zip /usr/lib/
+
+RUN unzip -d /usr/lib /usr/lib/extjs-4.1.1.zip; \
+    mv /usr/lib/ext-4.1.1a /usr/lib/extjs
 
 COPY install_famfamfam.rb /usr/src/app/
 RUN /usr/src/app/install_famfamfam.rb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@
 # docker-compose -f docker-compose.demo.yml build
 # docker-compose -f docker-compose.demo.yml up -d db
 # docker-compose -f docker-compose.demo.yml run bikeshed rake db:setup
+# docker-compose -f docker-compose.demo.yml restart db
 # docker-compose -f docker-compose.demo.yml up -d bikeshed
 
 db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,12 @@
+# BikeShed
+#
+# cp config/database.yml.example config/database.yml
+#
+# docker-compose -f docker-compose.demo.yml build
+# docker-compose -f docker-compose.demo.yml up -d db
+# docker-compose -f docker-compose.demo.yml run bikeshed rake db:setup
+# docker-compose -f docker-compose.demo.yml up -d bikeshed
+
 db:
   image: postgres
   ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@
 # docker-compose -f docker-compose.demo.yml build
 # docker-compose -f docker-compose.demo.yml up -d db
 # docker-compose -f docker-compose.demo.yml run bikeshed rake db:setup
-# docker-compose -f docker-compose.demo.yml restart db
 # docker-compose -f docker-compose.demo.yml up -d bikeshed
 
 db:


### PR DESCRIPTION
1. Speed-up nokogiri install significantly by turning off lib compilation in Dockerfile
2. File at http://my.jasondenney.com/extjs-4.1.1.zip can't be found, but
it has been used for a long time.  Now just including it in the
repository.
3. Added helpful documentation in docker-compose.yml